### PR TITLE
Demonstrate another method of tag-based deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,18 +11,20 @@ workflows:
           filters:
             tags:
               only: /.*/
+            branches:
+              only: /.*/
 
       - deploy:
           requires:
             - build
           filters:
             tags:
-              only: /Release-.*/
+              only: /^\d+\.\d+\.\d+$/
             branches:
               only:
                 - master
           context:
-            - CLOJARS_DEPLOY
+            - clojars-deploy
 
 jobs:
   build:
@@ -51,7 +53,7 @@ jobs:
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
-      - run: lein deps
+      - run: PROFILE=dev lein deps
 
       - save_cache:
           paths:
@@ -59,7 +61,7 @@ jobs:
           key: v1-dependencies-{{ checksum "project.clj" }}
       - run:
           name: Ensure No Reflection Warnings
-          command: "! lein check 2>&1 | grep 'Reflection warning'"          
+          command: "! lein check 2>&1 | grep 'Reflection warning'"
       # run tests!
       - run: lein midje
 
@@ -90,20 +92,6 @@ jobs:
             - v1-dependencies-
 
       - run:
-         name: Install babashka
-         command: |
-           curl -s https://raw.githubusercontent.com/borkdude/babashka/master/install -o install.sh
-           sudo bash install.sh
-           rm install.sh
-      - run:
-          name: Install deployment-script
-          command: |
-            curl -s https://raw.githubusercontent.com/clj-commons/infra/main/deployment/circle-maybe-deploy.bb -o circle-maybe-deploy.bb
-            chmod a+x circle-maybe-deploy.bb
-
-      - run: lein deps
-
-      - run:
           name: Setup GPG signing key
           command: |
             GNUPGHOME="$HOME/.gnupg"
@@ -127,5 +115,4 @@ jobs:
            GPG_TTY=$(tty)
            export GPG_TTY
            echo $GPG_TTY
-           ./circle-maybe-deploy.bb lein deploy clojars
-        
+           lein deploy clojars

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-commons/fs (or (System/getenv "PROJECT_VERSION") "0.1.0-SNAPSHOT")
+(defproject cddr/fs :project/git-ref-short
   :description "File system utilities for clojure"
   :license {:name "Eclipse Public License - v 1.0"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
@@ -16,8 +16,19 @@
                  [org.tukaani/xz "1.8"]]
   :plugins [[lein-midje "3.1.3"]
             [codox "0.8.10"]
-            [lein-ancient "0.6.15"]]
+            [lein-ancient "0.6.15"]
+            [me.arrdem/lein-git-version "2.0.8"]]
   :codox {:src-dir-uri "https://github.com/clj-commons/fs/blob/master/"
           :src-linenum-anchor-prefix "L"
           :defaults {:doc/format :markdown}}
-  :profiles {:dev {:dependencies [[midje "1.9.4"]]}})
+  :profiles {:dev {:dependencies [[midje "1.9.4"]]}}
+  :git-version {:status-to-version
+                (fn [{:keys [tag version branch ahead ahead? dirty?] :as git}]
+                  (assert (re-find #"\d+\.\d+\.\d+" tag)
+                          "Tag is assumed to be a raw SemVer version")
+                  (if (and tag (not ahead?) (not dirty?))
+                    tag
+                    (let [[_ prefix patch] (re-find #"(\d+\.\d+)\.(\d+)" tag)
+                          patch            (Long/parseLong patch)
+                          patch+           (inc patch)]
+                      (format "%s.%d-%s-SNAPSHOT" prefix patch+ branch))))})


### PR DESCRIPTION
There's been recent work to generate the project version from the git tag but I think we can make this a bit simpler and require fewer dependencies in the build pipeline.

This PR uses the [lein-git-version](https://github.com/arrdem/lein-git-version) plugin which injects information about the current git version into the project map. This means you can use a placeholder like `:project/git-short-ref` in the project.clj source code but tools like `lein pom`, `lein jar`, `lein deploy` etc all get to see the version as derived from git tags.

Testing out deployment at the moment using an artifact under my own "cddr" namespace but if this works and folks would like it, happy to rebase the PR against the original project. Basically aiming for a circle config that

 * builds/tests changes applied to any branch
 * publish snapshot builds when PRs are merged to master
 * publish full releases when tags are pushed to github